### PR TITLE
chore: update GitHub URL to new skillenai org

### DIFF
--- a/skill-value-by-seniority/make_carousel.py
+++ b/skill-value-by-seniority/make_carousel.py
@@ -336,7 +336,7 @@ def slide_cta():
             url=full_blog)
 
     # GitHub link
-    gh_short = "github.com/chiefastro/skillenai-notebooks/tree/master/skill-value-by-seniority"
+    gh_short = "github.com/skillenai/skillenai-notebooks/tree/master/skill-value-by-seniority"
     gh_full = "https://" + gh_short
     ax.text(50, 43, "Code + data", ha="center", va="center",
             fontsize=13, color=INK, weight="bold")


### PR DESCRIPTION
## Summary
- Repo transferred from `chiefastro` to `skillenai` org.
- Updates the footer link in `skill-value-by-seniority/make_carousel.py`. Published LinkedIn posts left as-is (historical).

## Test plan
- [ ] Visual diff only — carousel regenerates on next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)