### PR TITLE
Add LinkedIn post for ai-engineer-talent-flows

### DIFF
--- a/ai-engineer-talent-flows/linkedin-post.md
+++ b/ai-engineer-talent-flows/linkedin-post.md
@@ -1,0 +1,37 @@
+# LinkedIn post
+
+*Post the blog link as the FIRST COMMENT, not in the body (inline links suppress reach). Swap in the public blog URL once the post is published from the dashboard.*
+
+---
+
+Software Engineers are the #1 feeder into AI Engineering. But the skills they bring aren't the ones employers actually want.
+
+We mapped the AI Engineer role from both sides — Skillenai's talent graph (who moves into the role) and job postings (what employers ask for).
+
+Who becomes an AI Engineer? Software Engineers (22%), then ML Engineers (14%) and Data Scientists (13%), plus a long tail from analytics and academia. There is no single "right" background.
+
+Then we put both sides of the skill market on one chart, and they don't line up.
+
+Demand runs ahead on the LLM stack: LLMs, prompt engineering, RAG, vector databases, evaluation, guardrails. Employers ask 2-4x more than AI Engineers list them.
+
+Supply lags with legacy skills: SQL, Excel, TensorFlow, computer vision — the toolkits of the roles people came FROM.
+
+The skill gap is the fingerprint of the transition. People arrive carrying where they came from; demand points where the role is going.
+
+So if you're moving into AI Engineering, the gap is your syllabus: RAG, agents, evals, guardrails, vector DBs.
+
+It's also the fastest-growing role of its neighbors — still accelerating while Data Science plateaus.
+
+Which of these skills are you building right now?
+
+---
+
+**First comment:** Full analysis, charts, and methodology → [blog URL once published]  ·  Data + code: https://github.com/skillenai/skillenai-notebooks/tree/master/ai-engineer-talent-flows
+
+<!-- model score (scripts/linkedin_scoring/score.py):
+predicted impressions: 4,238  ·  engagements: 39  ·  followers_3d: 22
+Acronym-rich (AI/ML/DS/LLM/RAG/SQL), ends with a question, no inline URL (link -> first comment),
+no unicode bullets. Only suggestion returned was "add an exclamation" — declined (known-unreliable;
+exclamation_count was a NEGATIVE per-draft driver here). Not iterated further: strong baseline,
+only suggestion was adversarial.
+-->


### PR DESCRIPTION
Scored LinkedIn draft (leads on the supply-demand skill gap) for the merged owned-graph analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)